### PR TITLE
created simpler solution DP->CountNumberOfBinaryWithoutConsecutive1s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target/
 .classpath
 .project
 .settings/
+/bin/

--- a/src/com/interview/dynamic/CountNumberOfBinaryWithoutConsecutive1s.java
+++ b/src/com/interview/dynamic/CountNumberOfBinaryWithoutConsecutive1s.java
@@ -23,6 +23,19 @@ public class CountNumberOfBinaryWithoutConsecutive1s {
         return a[n-1] + b[n-1];
     }
     
+    public int countSimple(int n){
+        int a = 1;
+        int b = 1;
+        
+        for(int i=1; i < n; i++){
+            int tmp = a;
+        	a = a + b;
+            b = tmp;
+        }
+        
+        return a + b;
+    }
+    
     public static void main(String args[]){
         CountNumberOfBinaryWithoutConsecutive1s cnb = new CountNumberOfBinaryWithoutConsecutive1s();
         System.out.println(cnb.count(5));


### PR DESCRIPTION
We didn't need to store all the Fibonacci numbers up to the last ones, since we only need the last two all the time. The method added is thus saving memory.