### PR TITLE
Add guava dependency to build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ repositories {
 
 dependencies {
     testCompile 'junit:junit:4.12'
+    compile 'com.google.guava:guava:23.3-jre'
 }
 
 sourceSets {


### PR DESCRIPTION
Add Guava dependency to fix:

> Error:(3, 33) java: package com.google.common.collect does not exist

in /src/com/interview/multithreaded/DependencyTaskExecutor.java