### PR TITLE
removed com.google.common.collect.Lists

### DIFF
--- a/src/com/interview/multithreaded/DependencyTaskExecutor.java
+++ b/src/com/interview/multithreaded/DependencyTaskExecutor.java
@@ -1,8 +1,9 @@
 package com.interview.multithreaded;
 
-import com.google.common.collect.Lists;
+
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -63,7 +64,8 @@ public class DependencyTaskExecutor {
         x.addDependency(y);
         x.addDependency(z);
         y.addDependency(a);
-        taskExecutor.scheduleTask(Lists.newArrayList(a, b, c, d, x, y, z), 4);
+        
+        taskExecutor.scheduleTask(Arrays.asList(a, b, c, d, x, y, z), 4);
     }
 }
 


### PR DESCRIPTION
Google List API is not required, same result can be achieved by using Arrays.asList Java API

1. This change will simplify code understanding.
2. removed overhead of importing google library in source code