### PR TITLE
fixed int to double comparison in rabin karp and linted

### DIFF
--- a/python/string/rabinkarp.py
+++ b/python/string/rabinkarp.py
@@ -5,49 +5,41 @@ prime = 101
 def pattern_matching(text, pattern):
     m = len(pattern)
     n = len(text)
-    pattern_hash = create_hash(pattern, m - 1)
-    text_hash = create_hash(text, m - 1)
-
-    for i in range(1, n - m + 2):
+    pattern_hash = create_hash(pattern, m)
+    text_hash = create_hash(text, m)
+    for i in range(0, n - m + 1):
         if pattern_hash == text_hash:
-            if check_equal(text[i-1:i+m-1], pattern[0:]) is True:
-                return i - 1;
-        if i < n - m + 1:    
-            text_hash = recalculate_hash(text, i-1, i+m-1, text_hash, m)
-    return -1;
-    
+            if check_equal(text[i:i+m], pattern):
+                return i
+        if i < n - m:
+            text_hash = recalculate_hash(text, i, i+m, text_hash, m)
+    return -1
+
 def check_equal(str1, str2):
     if len(str1) != len(str2):
-        return False;
-    i = 0
-    j = 0
+        return False
     for i, j in zip(str1, str2):
         if i != j:
-            return False;
+            return False
     return True
-    
+
 def create_hash(input, end):
     hash = 0
-    for i in range(end + 1):
+    for i in range(0, end):
         hash = hash + ord(input[i])*pow(prime, i)
     return hash
 
 def recalculate_hash(input, old_index, new_index, old_hash, pattern_len):
     new_hash = old_hash - ord(input[old_index])
-    new_hash = new_hash/prime
+    new_hash //= prime
     new_hash += ord(input[new_index])*pow(prime, pattern_len - 1)
-    return new_hash;
+    # print(locals(), new_hash) # uncomment to debug
+    return new_hash
 
-
-index = pattern_matching("TusharRoy", "sharRoy")
-print("Index ", index)
-index = pattern_matching("TusharRoy", "Roy")
-print("Index ", index)
-index = pattern_matching("TusharRoy", "shar")
-print("Index ", index)
-index = pattern_matching("TusharRoy", "usha")
-print("Index ", index)
-index = pattern_matching("TusharRoy", "Tus")
-print("Index ", index)
-index = pattern_matching("TusharRoy", "Roa")
-print("Index ", index)
+inputs = [("TusharRoy", "sharRoy"), ("TusharRoy", "Roy"),
+    ("TusharRoy", "shar"), ("TusharRoy", "usha"),
+    ("TusharRoy", "Tus"), ("TusharRoy", "Roa"),
+    ("abcd", "cd")]
+for text, pattern in inputs:
+    index = pattern_matching(text, pattern)
+    print("{} in {} at {}".format(pattern, text, index))


### PR DESCRIPTION
Comparing int to double is problematic therefore, changed `new_hash /= prime` to `new_hash //= prime`. `/` operator returns double `//` operator returns int.

Also linted, added some debug info and normalized the indexes
