### PR TITLE
Change how midpoint is calculated in SortedArrayToBST.java

### DIFF
--- a/src/com/interview/tree/SortedArrayToBST.java
+++ b/src/com/interview/tree/SortedArrayToBST.java
@@ -7,7 +7,7 @@ package com.interview.tree;
  * Given an array where elements are sorted in ascending order, convert it to a height balanced BST.
  *
  * Time complexity O(n)
- * 
+ *
  * Reference
  * https://leetcode.com/problems/convert-sorted-array-to-binary-search-tree/
  */
@@ -20,7 +20,7 @@ public class SortedArrayToBST {
         if (low > high) {
             return null;
         }
-        int mid = (low + high)/2;
+        int mid = low + (high - low)/2;
         Node n = Node.newNode(nums[mid]);
         n.left = toBST(nums, low, mid - 1);
         n.right = toBST(nums, mid + 1, high);


### PR DESCRIPTION
## Context

As currently written, in SortedArraytoBST.java, we compute the middle index of the sorted array as follows:

`int mid = (low + high) / 2`

This is fine most of the time -- however, integer overflow may occur in some cases. For example, suppose 'low' and 'high' are 16 bit unsigned integers. Their maximum value is 2^16=65536. If low is 65530 and high is 65531 then their sum will overflow.

Integer overflow becomes less likely if we compute middle index like this:
`int mid = low + (high - low) / 2`