### PR TITLE
Update MaxSumForNonAdjacentElements.java

### DIFF
--- a/src/com/interview/dynamic/MaxSumForNonAdjacentElements.java
+++ b/src/com/interview/dynamic/MaxSumForNonAdjacentElements.java
@@ -20,8 +20,12 @@ public class MaxSumForNonAdjacentElements {
      * Fast DP solution.
      */
     public int maxSum(int arr[]) {
+        /*Added corner cases based on length of array */
+        if (arr.length == 0) return 0;
+        if (arr.length == 1) return arr[0];
         int excl = 0;
-        int incl = arr[0];
+        /*Find max of arr[0], 0 and assign to inclusive */
+        int incl = Math.max(arr[0],0);
         for (int i = 1; i < arr.length; i++) {
             int temp = incl;
             incl = Math.max(excl + arr[i], incl);


### PR DESCRIPTION
1. Added corner cases based on the length of the array. 
2. arr[0] needs to be max(0, arr[0]). 
The assumption that the empty set is a valid subset comes into play. Were we to only consider subsets of size >= 1, we'd have to concern ourselves with finding the least negative number in an array of purely negative numbers. However, since we can use the empty set, 0 is a valid sum for an array of purely negative integers.
