### PR TITLE
correct the bug that removes a prefix word when removing a longer word

### DIFF
--- a/src/com/interview/suffixprefix/Trie.java
+++ b/src/com/interview/suffixprefix/Trie.java
@@ -140,7 +140,7 @@ public class Trie {
         if (shouldDeleteCurrentNode) {
             current.children.remove(ch);
             //return true if no mappings are left in the map.
-            return current.children.size() == 0;
+            return (current.children.size() == 0 && !current.endOfWord);
         }
         return false;
     }


### PR DESCRIPTION
If the Trie has the been inserted with 'apple', then 'app', later the 'apple' got removed from Trie and search for app will fail. Therefore, corrected the condition at the return statement to fix this. 