### PR TITLE
chore(upgrade): update gradle version, update google.guava version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,8 @@ repositories {
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
+    implementation 'com.google.guava:guava:33.4.8-jre'
 }
 
 sourceSets {
@@ -30,8 +31,9 @@ sourceSets {
 
 jacocoTestReport {
     reports {
-        xml.enabled false
-        csv.enabled false
-        html.destination "${buildDir}/jacocoHtml"
+        xml.required.set(false)
+        csv.required.set(false)
+        html.required.set(true)
+        html.outputLocation.set(file("${buildDir}/jacocoHtml"))
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Apr 02 16:59:09 PDT 2016
+#Mon Jun 09 18:39:30 PDT 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.11-bin.zip


### PR DESCRIPTION
This PR upgrades the build system and improves compatibility with modern Gradle versions.

### 🔧 Changes Made

* ⬆️ **Upgraded Gradle wrapper** from `2.11` to `8.13`
  Ensures compatibility with current Java toolchains and enables modern Gradle features.
* 🔁 **Replaced deprecated `testCompile`** with `testImplementation`
* 📦 **Added Guava dependency**
  `com.google.guava:guava:33.4.8-jre` to resolve missing `com.google.common.collect.Lists` usage.
* 🧪 **Updated `jacocoTestReport` configuration**:

  * Replaced deprecated `enabled = false` with `required.set(false)`
  * Updated `html.destination` → `outputLocation.set(...)` per Gradle 8+ guidelines

### 📌 Motivation

* Fixes compilation issues due to missing Guava dependency
* Resolves deprecated Gradle configuration errors
* Modernizes the build setup for future maintenance and enhancements